### PR TITLE
sweet: only enable gvisor benchmark by default for amd64

### DIFF
--- a/sweet/cmd/sweet/benchmark.go
+++ b/sweet/cmd/sweet/benchmark.go
@@ -102,10 +102,11 @@ var benchmarkGroups = func() map[string][]*benchmark {
 		allBenchmarksMap["etcd"],
 		allBenchmarksMap["go-build"],
 		allBenchmarksMap["gopher-lua"],
-		allBenchmarksMap["gvisor"],
-		allBenchmarksMap["markdown"],
-		allBenchmarksMap["tile38"],
 	}
+	if runtime.GOARCH == "amd64" {
+		m["default"] = append(m["default"], allBenchmarksMap["gvisor"])
+	}
+	m["default"] = append(m["default"], allBenchmarksMap["markdown"], allBenchmarksMap["tile38"])
 
 	for i := range allBenchmarks {
 		m["all"] = append(m["all"], &allBenchmarks[i])

--- a/sweet/harnesses/gvisor.go
+++ b/sweet/harnesses/gvisor.go
@@ -21,6 +21,9 @@ func (h GVisor) CheckPrerequisites() error {
 	if runtime.GOOS != "linux" {
 		return fmt.Errorf("requires Linux")
 	}
+	if runtime.GOARCH != "amd64" {
+		return fmt.Errorf("requires amd64")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Currently this benchmark suite only run on amd64. This CL removes it from the default benchmarks for other architectures, so that "sweet run" can pass by default.

This CL also adds a prerequisite check for amd64, so that it can report errors in advance.

Fixes #67869