### PR TITLE
x/benchmarks/sweet: change dir when building

### DIFF
--- a/sweet/harnesses/go-build.go
+++ b/sweet/harnesses/go-build.go
@@ -111,7 +111,7 @@ func (h GoBuild) Build(pcfg *common.Config, bcfg *common.BuildConfig) error {
 		return fmt.Errorf("error copying GOROOT: %v", err)
 	}
 	cfg.GoRoot = goroot
-	if err := cfg.GoTool().Do("", "install", "cmd/compile", "cmd/link"); err != nil {
+	if err := cfg.GoTool().Do(cfg.GoRoot, "install", "cmd/compile", "cmd/link"); err != nil {
 		return fmt.Errorf("error building cmd/compile and cmd/link: %v", err)
 	}
 


### PR DESCRIPTION
change dir to cfg.GoRoot to avoid installing cmd/compile cmd/link in pkg/mod specified by benchmarks' go.mod.

Fixes https://github.com/golang/go/issues/72920
