### PR TITLE
cmd/bent: disable ethereum_whisper benchmark

### DIFF
--- a/cmd/bent/configs/suites.toml
+++ b/cmd/bent/configs/suites.toml
@@ -119,6 +119,7 @@
   Repo = "github.com/ethereum/go-ethereum/whisper/whisperv6"
   Benchmarks = "Benchmark"
   NotSandboxed = true # Won't cross-compile to Linux on MacOS
+  Disabled = true # Whisper protocol has been deprecated and removed from v1.9.24+ versions. v1.9.2 has missing dependency.
   Version = "@v1.9.2"
 
 [[Suites]]


### PR DESCRIPTION
This PR disables the `ethereum_whisper` benchmark in `suites.toml` since:
- The protocol is deprecated
- No working version can be found (v1.9.2 has dependency issues, 
  newer versions don't contain the package)
- The benchmark cannot be built successfully